### PR TITLE
Update QAAC_AAC.format

### DIFF
--- a/formats/encoder/QAAC_AAC.format
+++ b/formats/encoder/QAAC_AAC.format
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<Format id="QAAC_AAC" name="AAC (MPEG-2/AAC) - qaac" template="$EXE $OPTIONS --ignorelength --adts $INFILE -o $OUTFILE" input="true" output="false" function="GetProgress_QaacEnc.progress" path="qaac.exe" success="0" type="0" formats="WAV" extension="AAC" default="7">
+<Format id="QAAC_AAC" name="AAC (MPEG-2/AAC) - qaac" template="$EXE $OPTIONS --ignorelength --no-optimize $INFILE -o $OUTFILE" input="true" output="false" function="GetProgress_QaacEnc.progress" path="qaac.exe" success="0" type="0" formats="WAV" extension="AAC" default="7">
     <Presets>
         <Preset name="True VBR Quality 0 : 40 kbps~" options="--tvbr 0"/>
         <Preset name="True VBR Quality 9 : 48 kbps~" options="--tvbr 9"/>


### PR DESCRIPTION
This sometimes causes audio to have wrong time (bigger length than original), I also don't see the reason of having this options since it's mainly for streaming audio https://wiki.multimedia.cx/index.php/ADTS and we are not trying to stream audio we are trying to convert audio.
--no-optimize is something I've copied from foobar, but here is what it does according to the manual 
" --no-optimize          Don't optimize MP4 container after encoding. "